### PR TITLE
Persist data with SQL Server

### DIFF
--- a/src/WorkoutRecords.Domain/DDD/Distance.cs
+++ b/src/WorkoutRecords.Domain/DDD/Distance.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -38,4 +39,6 @@ public class Distance : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Distance> Distances { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/DistanceWeightWorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/DistanceWeightWorkoutMovement.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class DistanceWeightWorkoutMovement : WorkoutMovement
 {
@@ -27,4 +29,6 @@ public class DistanceWeightWorkoutMovement : WorkoutMovement
         yield return Distance;
         yield return Weight;
     }
+
+    public DbSet<DistanceWeightWorkoutMovement> DistanceWeightWorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/DistanceWorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/DistanceWorkoutMovement.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class DistanceWorkoutMovement : WorkoutMovement
 {
@@ -20,4 +22,6 @@ public class DistanceWorkoutMovement : WorkoutMovement
         yield return Movement;
         yield return Distance;
     }
+
+    public DbSet<DistanceWorkoutMovement> DistanceWorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Movement.cs
+++ b/src/WorkoutRecords.Domain/DDD/Movement.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.SeedWork;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
 
@@ -89,4 +90,6 @@ public class Movement : Enumeration
     public static Movement FromName(string name) => FromDisplayName<Movement>(name);
 
     public static IEnumerable<Movement> GetAll() => GetAll<Movement>();
+
+    public DbSet<Movement> Movements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Name.cs
+++ b/src/WorkoutRecords.Domain/DDD/Name.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -51,4 +52,6 @@ public class Name : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Name> Names { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Record.cs
+++ b/src/WorkoutRecords.Domain/DDD/Record.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.SeedWork;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
 
@@ -19,4 +20,6 @@ public abstract class Record(DateOnly date) : ValueObject
     public bool IsAfter(Record other) => Date > other.Date;
 
     public abstract bool IsBetterThan(Record other);
+
+    public DbSet<Record> Records { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/RecordHistory.cs
+++ b/src/WorkoutRecords.Domain/DDD/RecordHistory.cs
@@ -1,6 +1,7 @@
-﻿using StronglyTypedIds;
+using StronglyTypedIds;
 using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
+using Microsoft.EntityFrameworkCore;
 
 namespace WorkoutRecords.Domain.DDD;
 
@@ -74,3 +75,5 @@ public class WeightRecordHistory : RecordHistory<WeightRecord>
 
 [StronglyTypedId(converters: StronglyTypedIdConverter.None)]
 public partial struct RecordHistoryId;
+
+public DbSet<RecordHistory> RecordHistories { get; set; }

--- a/src/WorkoutRecords.Domain/DDD/Reps.cs
+++ b/src/WorkoutRecords.Domain/DDD/Reps.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -38,4 +39,6 @@ public class Reps : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Reps> Reps { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/RepsRecord.cs
+++ b/src/WorkoutRecords.Domain/DDD/RepsRecord.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class RepsRecord : Record
 {
@@ -35,4 +37,6 @@ public class RepsRecord : Record
         yield return Date;
         yield return Reps;
     }
+
+    public DbSet<RepsRecord> RepsRecords { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/RepsWeightWorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/RepsWeightWorkoutMovement.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class RepsWeightWorkoutMovement : WorkoutMovement
 {
@@ -24,4 +26,6 @@ public class RepsWeightWorkoutMovement : WorkoutMovement
         yield return Reps;
         yield return Weight;
     }
+
+    public DbSet<RepsWeightWorkoutMovement> RepsWeightWorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/RepsWorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/RepsWorkoutMovement.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class RepsWorkoutMovement : WorkoutMovement
 {
@@ -20,4 +22,6 @@ public class RepsWorkoutMovement : WorkoutMovement
         yield return Movement;
         yield return Reps;
     }
+
+    public DbSet<RepsWorkoutMovement> RepsWorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Rounds.cs
+++ b/src/WorkoutRecords.Domain/DDD/Rounds.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -40,4 +41,6 @@ public class Rounds : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Rounds> Rounds { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Time.cs
+++ b/src/WorkoutRecords.Domain/DDD/Time.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -36,4 +37,6 @@ public class Time : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Time> Times { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/TimeRecord.cs
+++ b/src/WorkoutRecords.Domain/DDD/TimeRecord.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class TimeRecord : Record
 {
@@ -36,4 +38,6 @@ public class TimeRecord : Record
         yield return Date;
         yield return Time;
     }
+
+    public DbSet<TimeRecord> TimeRecords { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/TimeWorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/TimeWorkoutMovement.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class TimeWorkoutMovement : WorkoutMovement
 {
@@ -20,4 +22,6 @@ public class TimeWorkoutMovement : WorkoutMovement
         yield return Movement;
         yield return Time;
     }
+
+    public DbSet<TimeWorkoutMovement> TimeWorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Weight.cs
+++ b/src/WorkoutRecords.Domain/DDD/Weight.cs
@@ -1,4 +1,5 @@
-﻿using WorkoutRecords.Domain.DDD.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using WorkoutRecords.Domain.DDD.Exceptions;
 using WorkoutRecords.Domain.DDD.SeedWork;
 
 namespace WorkoutRecords.Domain.DDD;
@@ -38,4 +39,6 @@ public class Weight : ValueObject
     {
         yield return _value;
     }
+
+    public DbSet<Weight> Weights { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/WeightRecord.cs
+++ b/src/WorkoutRecords.Domain/DDD/WeightRecord.cs
@@ -1,4 +1,6 @@
-﻿namespace WorkoutRecords.Domain.DDD;
+using Microsoft.EntityFrameworkCore;
+
+namespace WorkoutRecords.Domain.DDD;
 
 public class WeightRecord : Record
 {
@@ -38,4 +40,6 @@ public class WeightRecord : Record
         yield return Date;
         yield return Weight;
     }
+
+    public DbSet<WeightRecord> WeightRecords { get; set; }
 }

--- a/src/WorkoutRecords.Domain/DDD/Workout.cs
+++ b/src/WorkoutRecords.Domain/DDD/Workout.cs
@@ -1,5 +1,6 @@
-﻿using StronglyTypedIds;
+using StronglyTypedIds;
 using WorkoutRecords.Domain.DDD.SeedWork;
+using Microsoft.EntityFrameworkCore;
 
 namespace WorkoutRecords.Domain.DDD;
 
@@ -27,6 +28,8 @@ public class Workout : Entity<WorkoutId>, IAggregateRoot
         new(WorkoutId.New(), name, timeCap, rounds);
 
     public void Comprise(WorkoutMovement movement) => _movements.Add(movement);
+
+    public DbSet<Workout> Workouts { get; set; }
 }
 
 [StronglyTypedId(converters: StronglyTypedIdConverter.None)]

--- a/src/WorkoutRecords.Domain/DDD/WorkoutMovement.cs
+++ b/src/WorkoutRecords.Domain/DDD/WorkoutMovement.cs
@@ -1,9 +1,11 @@
-﻿using WorkoutRecords.Domain.DDD;
+using WorkoutRecords.Domain.DDD;
 using WorkoutRecords.Domain.DDD.SeedWork;
+using Microsoft.EntityFrameworkCore;
 
 namespace WorkoutRecords.Domain;
 
 public abstract class WorkoutMovement(Movement movement) : ValueObject
 {
     public Movement Movement { get; } = movement;
+    public DbSet<WorkoutMovement> WorkoutMovements { get; set; }
 }

--- a/src/WorkoutRecords.Domain/WorkoutRecords.Domain.csproj
+++ b/src/WorkoutRecords.Domain/WorkoutRecords.Domain.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="StronglyTypedId" Version="1.0.0-beta06" PrivateAssets="all" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #14

Add SQL Server persistence to the project.

* **Project File Changes**
  - Add `Microsoft.EntityFrameworkCore` and `Microsoft.EntityFrameworkCore.SqlServer` package references to `src/WorkoutRecords.Domain/WorkoutRecords.Domain.csproj`.

* **Domain Model Changes**
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<Workout> Workouts { get; set; }` to `src/WorkoutRecords.Domain/DDD/Workout.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<WorkoutMovement> WorkoutMovements { get; set; }` to `src/WorkoutRecords.Domain/DDD/WorkoutMovement.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<DistanceWorkoutMovement> DistanceWorkoutMovements { get; set; }` to `src/WorkoutRecords.Domain/DDD/DistanceWorkoutMovement.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<DistanceWeightWorkoutMovement> DistanceWeightWorkoutMovements { get; set; }` to `src/WorkoutRecords.Domain/DDD/DistanceWeightWorkoutMovement.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<Distance> Distances { get; set; }` to `src/WorkoutRecords.Domain/DDD/Distance.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<Weight> Weights { get; set; }` to `src/WorkoutRecords.Domain/DDD/Weight.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<Movement> Movements { get; set; }` to `src/WorkoutRecords.Domain/DDD/Movement.cs`.
  - Add `using Microsoft.EntityFrameworkCore;` and `public DbSet<Name> Names { get; set; }` to `src/WorkoutRecords.Domain/DDD/Name.cs`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jhiben/workout-records-api-dotnet/pull/56?shareId=9c36f9b6-8163-43a2-bad8-c9e47aa5dbff).